### PR TITLE
Submit header information with client request

### DIFF
--- a/lib/rpcclient.js
+++ b/lib/rpcclient.js
@@ -96,6 +96,7 @@ var Client = function (options) {
         'host': conf.host + ':' + conf.port,
         'content-type': conf.contentType,
         'content-length': opts.length,
+	'X-Requested-With':'XMLHttpRequest'
       }
     };
 

--- a/lib/rpcclient.js
+++ b/lib/rpcclient.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var https = require('https');
 var buffer = require('buffer');
+var extend = require('object-assign');
 
 /* Rpc Client Object
  *
@@ -44,6 +45,7 @@ var Client = function (options) {
 
     hash: options.hash || null,
     login: options.login || null,
+    headers: options.headers || {}
   };
 
   if (options.ssl) {
@@ -92,12 +94,11 @@ var Client = function (options) {
       port: conf.port,
       path: opts.path,
 
-      headers: {
+      headers: extend({
         'host': conf.host + ':' + conf.port,
         'content-type': conf.contentType,
-        'content-length': opts.length,
-	'X-Requested-With':'XMLHttpRequest'
-      }
+        'content-length': opts.length
+      },opts.headers)
     };
 
     if (opts.login && opts.hash)
@@ -151,7 +152,8 @@ var Client = function (options) {
       path: opts.path || conf.path,
 
       login: opts.login || conf.login,
-      hash: opts.hash || conf.hash
+      hash: opts.hash || conf.hash,
+      headers: opts.headers || conf.headers
     });
 
     var request = serv.request(options);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Flexible client, server objects for json-rpc communications",
   "author": "Koen Van Rulo (@NemoPersona)",
   "license": "BSD",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "./lib/index.js",
   "keywords": [
     "server",

--- a/package.json
+++ b/package.json
@@ -2,28 +2,26 @@
   "name": "node-json-rpc",
   "description": "Flexible client, server objects for json-rpc communications",
   "author": "Koen Van Rulo (@NemoPersona)",
-  
   "license": "BSD",
   "version": "0.0.1",
   "main": "./lib/index.js",
-
   "keywords": [
     "server",
     "client",
     "json",
     "rpc"
   ],
-
   "repository": {
     "type": "git",
     "url": "https://github.com/NemoPersona/node-json-rpc.git"
   },
-
   "scripts": {
     "test": "node ./test/rpc.js"
   },
-
   "engines": {
     "node": ">= 0.10.0"
+  },
+  "dependencies": {
+    "object-assign": "^4.0.1"
   }
 }


### PR DESCRIPTION
Any header information passed when creating a new client or making a call now gets added and overrides any defaults. 